### PR TITLE
fix: Windows fseek64 for large GGUF models and MinGW compatibility

### DIFF
--- a/src/weight-store.cpp
+++ b/src/weight-store.cpp
@@ -21,7 +21,11 @@ bool load_tensor_data(FILE* file,
     const size_t offset = gguf_get_data_offset(gguf_ctx) + gguf_get_tensor_offset(gguf_ctx, tensor_idx);
     const size_t nbytes = ggml_nbytes(tensor);
 
-    if (fseek(file, static_cast<long>(offset), SEEK_SET) != 0) {
+#ifdef _WIN32
+    if (_fseeki64(file, static_cast<__int64>(offset), SEEK_SET) != 0) {
+#else
+    if (fseeko(file, static_cast<off_t>(offset), SEEK_SET) != 0) {
+#endif
         return false;
     }
 

--- a/third_party/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/third_party/ggml/src/ggml-cpu/ggml-cpu.c
@@ -2480,7 +2480,7 @@ static bool ggml_thread_apply_priority(int32_t prio) {
         // Newer Windows 11 versions aggresively park (offline) CPU cores and often place
         // all our threads onto the first 4 cores which results in terrible performance with
         // n_threads > 4
-        #if _WIN32_WINNT >= 0x0602
+        #if _WIN32_WINNT >= 0x0602 && !defined(__MINGW32__) && !defined(__MINGW64__)
         THREAD_POWER_THROTTLING_STATE t;
         ZeroMemory(&t, sizeof(t));
         t.Version     = THREAD_POWER_THROTTLING_CURRENT_VERSION;


### PR DESCRIPTION
## Summary

This PR fixes two Windows-specific issues discovered when building and running VoxCPM.cpp with MinGW + Vulkan backend.

## Fixes

### 1. GGUF loading fails for models >2GB on Windows

**Problem:** `fseek()` uses `long` for the offset parameter. On Windows, `long` is 32-bit (max ~2.147GB). Loading F16/F32 models (>2GB) fails with "Failed to load GGUF".

**Fix:** Use `_fseeki64` (Windows) / `fseeko` (POSIX) for 64-bit file offsets.

**File:** `src/weight-store.cpp`

### 2. MinGW compilation fails

**Problem:** `THREAD_POWER_THROTTLING_STATE` is not defined in MinGW headers.

**Fix:** Skip this block when compiling with MinGW (`__MINGW32__` / `__MINGW64__`).

**File:** `third_party/ggml/src/ggml-cpu/ggml-cpu.c`

## Testing

- OS: Windows 11
- Compiler: MinGW-w64 GCC 13.2
- GPU: AMD RX 6700 XT (Vulkan backend)
- Models tested: `voxcpm2-f16.gguf` (~4.6GB), `voxcpm2-q4_k.gguf` (~1.4GB)

Both models now load and run successfully on Windows with MinGW.