### PR TITLE
Fix: make nlohmann_json available to the core library unconditionally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,16 +59,15 @@ set(GGML_CUDA ${VOXCPM_CUDA} CACHE BOOL "ggml: use CUDA" FORCE)
 set(GGML_NATIVE ${VOXCPM_NATIVE} CACHE BOOL "ggml: optimize the build for the current system" FORCE)
 add_subdirectory(${GGML_DIR} ggml)
 
-# nlohmann_json is only required for tests / trace tooling.
-if(VOXCPM_BUILD_TESTS)
-    set(JSON_DIR ${CMAKE_SOURCE_DIR}/third_party/json)
-    if(EXISTS ${JSON_DIR}/CMakeLists.txt)
-        add_subdirectory(${JSON_DIR} json)
-    else()
-        include(FetchContent)
-        FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
-        FetchContent_MakeAvailable(json)
-    endif()
+# nlohmann_json is a dependency of the core library (src/server_common.cpp),
+# not just the tests, so make it available unconditionally.
+set(JSON_DIR ${CMAKE_SOURCE_DIR}/third_party/json)
+if(EXISTS ${JSON_DIR}/CMakeLists.txt)
+    add_subdirectory(${JSON_DIR} json)
+else()
+    include(FetchContent)
+    FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
+    FetchContent_MakeAvailable(json)
 endif()
 
 # =============================================================================
@@ -117,9 +116,7 @@ target_link_libraries(voxcpm
         Threads::Threads
 )
 
-if(VOXCPM_BUILD_TESTS)
-    target_link_libraries(voxcpm PUBLIC nlohmann_json::nlohmann_json)
-endif()
+target_link_libraries(voxcpm PUBLIC nlohmann_json::nlohmann_json)
 
 target_compile_definitions(voxcpm
     PUBLIC


### PR DESCRIPTION
## Problem

`src/server_common.cpp` is part of the core `voxcpm` library and includes `<nlohmann/json.hpp>`, but the json dependency was only declared and linked inside `if(VOXCPM_BUILD_TESTS)`. Configuring with `-DVOXCPM_BUILD_TESTS=OFF` (e.g. the lean CPU build many users start from) fails to compile the core library:

```
src/server_common.cpp:15:10: fatal error: 'nlohmann/json.hpp' file not found
   15 | #include <nlohmann/json.hpp>
```

## Fix

Move the json availability block (`add_subdirectory` / `FetchContent`) and the `target_link_libraries(voxcpm PUBLIC nlohmann_json::nlohmann_json)` call out of the tests-only guard, so the core library always has the dependency it actually uses.

## Verification

Clean configure + build with tests disabled now succeeds:

```
cmake -B build -DVOXCPM_BUILD_BENCHMARK=OFF -DVOXCPM_BUILD_TESTS=OFF
cmake --build build -j16
# -> Built target voxcpm / voxcpm_tts / voxcpm-server, no manual json header needed
```

Smoke-tested on macOS (Apple M3 Max): built `voxcpm_tts` from a clean clone and ran VoxCPM2 (`voxcpm2-q4_k-audiovae-f16.gguf`) reference-mode synthesis end to end, producing valid 48kHz audio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)