### PR TITLE
Add support for other generation modes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Example response:
 Registers a reusable voice entry by uploading:
 
 - multipart field `id`: required, unique voice id
-- multipart field `text`: required, transcript for the reference audio
+- multipart field `text`: optional, transcript for the reference audio
 - multipart file `audio`: required, reference audio file
 
 Success response: `201 Created`
@@ -212,14 +212,14 @@ JSON request fields:
 
 - `model`: required string, must match the configured `--model-name`
 - `input`: required string, 1 to 4096 characters
-- `voice`: required
+- `voice`: optional
   - string voice id, for example `"taiyi"`
   - or object form `{ "id": "taiyi" }`
 - `response_format`: optional, defaults to `mp3`
   - supported values: `mp3`, `opus`, `flac`, `wav`, `pcm`
 - `speed`: optional float, range `0.25` to `4.0`
 - `stream_format`: optional, `audio` or `sse`
-- `instructions`: accepted for compatibility, but non-empty values currently return an error
+- `instructions`: now supported for v2 model.
 
 Response behavior:
 
@@ -413,7 +413,7 @@ curl -X POST http://127.0.0.1:8080/v1/audio/speech \
 ### Notes
 
 - The current server accepts a voice id string such as `"taiyi"` in the `voice` field.
-- `instructions` is accepted for compatibility but is not implemented in VoxCPM v1.
+- `instructions` is not supported for VoxCPM versions prior to v2.
 - `stream_format` supports `audio` and `sse`; `audio.delta` events carry the same encoded bytes and `format` value as the non-streaming path.
 - `opus` is emitted as an Ogg Opus container, not a raw Opus packet stream.
 - If you run the server under systemd, `CUDA_VISIBLE_DEVICES` only controls GPU visibility.

--- a/include/voxcpm/audio-vae.h
+++ b/include/voxcpm/audio-vae.h
@@ -179,7 +179,8 @@ private:
                                int kernel_size,
                                int stride,
                                int dilation,
-                               int padding) const;
+                               int padding,
+                               int output_padding) const;
 
     ggml_tensor* causal_conv1d_stateful(ggml_context* ctx,
                                         ggml_tensor* x,
@@ -189,6 +190,7 @@ private:
                                         int stride,
                                         int dilation,
                                         int padding,
+                                        int output_padding,
                                         AudioVAEStreamingDecodeState& state,
                                         const std::string& state_name) const;
 

--- a/include/voxcpm/audio-vae.h
+++ b/include/voxcpm/audio-vae.h
@@ -139,8 +139,10 @@ public:
     bool load_from_gguf(const std::string& gguf_path,
                         VoxCPMContext& weight_ctx,
                         VoxCPMContext& graph_ctx,
-                        VoxCPMBackend& backend);
-    bool load_from_store(const std::shared_ptr<VoxCPMWeightStore>& store);
+                        VoxCPMBackend& backend,
+                        const ModelVersion override_version = ModelVersion::Unknown);
+    bool load_from_store(const std::shared_ptr<VoxCPMWeightStore>& store,
+                         const ModelVersion override_version = ModelVersion::Unknown);
 
     std::vector<float> preprocess(std::vector<float> audio_data, int sample_rate = -1) const;
 

--- a/include/voxcpm/audio_io.h
+++ b/include/voxcpm/audio_io.h
@@ -39,6 +39,7 @@ std::vector<uint8_t> encode_audio(AudioResponseFormat format,
                                   const std::vector<float>& waveform,
                                   int sample_rate);
 std::string base64_encode(const uint8_t* data, size_t size);
+std::vector<uint8_t> base64_decode(const std::string& in);
 
 }  // namespace voxcpm
 

--- a/include/voxcpm/config.h
+++ b/include/voxcpm/config.h
@@ -19,6 +19,39 @@ namespace voxcpm {
 // AudioVAE Configuration
 // =============================================================================
 
+// ModelVersion labels must be ordered in the same direction as the enum values (presumably ascending).
+enum class ModelVersion {
+    Unknown,
+    v0_5,
+    v1_5,
+    v2_0
+};
+// Parse in descending order, since newer versions are more likely to be used.
+inline ModelVersion parse_model_version_from_str(const std::string& str) {
+    // Using wide string because we already include that library.
+    std::wstring wstr(str.length() + 1, L'\0');
+    mbstowcs(&wstr[0], str.c_str(), str.length()+1);
+    auto wcstr = wstr.c_str();
+    // This format was used in the 2.0 model file:
+    if (!wcscasecmp(wcstr, L"VoxCPM2"))     return ModelVersion::v2_0;
+    // This format was used by the `--model-name` parameter:
+    if (!wcscasecmp(wcstr, L"VoxCPM-2"))    return ModelVersion::v2_0;
+    if (!wcscasecmp(wcstr, L"VoxCPM-1.5"))  return ModelVersion::v1_5;
+    if (!wcscasecmp(wcstr, L"VoxCPM-0.5B")) return ModelVersion::v0_5;
+
+    // Needs <algorithm>:
+    /*
+     * std::string lower = str;
+     * std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+     * if (lower == "voxcpm2")     return ModelVersion::v2_0;
+     * if (lower == "voxcpm-2")    return ModelVersion::v2_0;
+     * if (lower == "voxcpm-1.5")  return ModelVersion::v1_5;
+     * if (lower == "voxcpm-0.5b") return ModelVersion::v0_5;
+    */
+
+    return ModelVersion::Unknown;
+}
+
 /**
  * @brief AudioVAE Configuration
  *
@@ -32,6 +65,9 @@ namespace voxcpm {
  * - decoder_rates: Upsampling factors for each decoder block (reverse order)
  */
 struct AudioVAEConfig {
+    // Model version
+    ModelVersion model_version = ModelVersion::Unknown;
+
     // Dimensions
     int encoder_dim = 128;      // Upstream torch default encoder channel dimension
     int latent_dim = 64;        // Latent space dimension

--- a/include/voxcpm/config.h
+++ b/include/voxcpm/config.h
@@ -12,8 +12,20 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <algorithm>
 
 namespace voxcpm {
+
+
+static inline int ascii_tolower_char(unsigned char c) {
+    return std::tolower(c);
+}
+inline std::string ascii_tolower(const std::string& str) {
+    std::string lower = str;
+    std::transform(lower.begin(), lower.end(), lower.begin(), ascii_tolower_char);
+    return lower;
+}
+
 
 // =============================================================================
 // AudioVAE Configuration
@@ -28,26 +40,13 @@ enum class ModelVersion {
 };
 // Parse in descending order, since newer versions are more likely to be used.
 inline ModelVersion parse_model_version_from_str(const std::string& str) {
-    // Using wide string because we already include that library.
-    std::wstring wstr(str.length() + 1, L'\0');
-    mbstowcs(&wstr[0], str.c_str(), str.length()+1);
-    auto wcstr = wstr.c_str();
+    std::string lower = ascii_tolower(str);
     // This format was used in the 2.0 model file:
-    if (!wcscasecmp(wcstr, L"VoxCPM2"))     return ModelVersion::v2_0;
+    if (lower == "voxcpm2")     return ModelVersion::v2_0;
     // This format was used by the `--model-name` parameter:
-    if (!wcscasecmp(wcstr, L"VoxCPM-2"))    return ModelVersion::v2_0;
-    if (!wcscasecmp(wcstr, L"VoxCPM-1.5"))  return ModelVersion::v1_5;
-    if (!wcscasecmp(wcstr, L"VoxCPM-0.5B")) return ModelVersion::v0_5;
-
-    // Needs <algorithm>:
-    /*
-     * std::string lower = str;
-     * std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
-     * if (lower == "voxcpm2")     return ModelVersion::v2_0;
-     * if (lower == "voxcpm-2")    return ModelVersion::v2_0;
-     * if (lower == "voxcpm-1.5")  return ModelVersion::v1_5;
-     * if (lower == "voxcpm-0.5b") return ModelVersion::v0_5;
-    */
+    if (lower == "voxcpm-2")    return ModelVersion::v2_0;
+    if (lower == "voxcpm-1.5")  return ModelVersion::v1_5;
+    if (lower == "voxcpm-0.5b") return ModelVersion::v0_5;
 
     return ModelVersion::Unknown;
 }

--- a/include/voxcpm/server_common.h
+++ b/include/voxcpm/server_common.h
@@ -18,9 +18,9 @@ namespace voxcpm {
 struct PromptFeatures {
     std::string id;
     std::string prompt_text;
-    std::vector<float> prompt_feat;
+    std::vector<float> prompt_feat;    // Left-padded.
     int prompt_audio_length = 0;
-    std::vector<float> reference_feat;
+    std::vector<float> reference_feat; // Right-padded.
     int reference_audio_length = 0;
     int sample_rate = 0;
     int patch_size = 0;
@@ -46,6 +46,7 @@ struct SynthesisRequest {
     PromptFeatures prompt;
     float cfg_value = 2.0f;
     int inference_timesteps = 10;
+    bool has_uploaded_prompt_audio = false;
     int streaming_prefix_len = 4;
     bool retry_badcase = false;
     int retry_badcase_max_times = 3;
@@ -89,6 +90,8 @@ public:
                                          const std::vector<float>& mono_audio,
                                          int sample_rate);
     SynthesisResult synthesize(const SynthesisRequest& request);
+    std::vector<float> convert_prompt_feat_to_reference_feat(
+                                      const std::vector<float>& prompt_feat);
 
     int sample_rate() const;
     int patch_size() const;

--- a/include/voxcpm/server_common.h
+++ b/include/voxcpm/server_common.h
@@ -81,7 +81,7 @@ class VoxCPMServiceCore {
 public:
     VoxCPMServiceCore(std::string model_path, BackendType backend_type, int threads);
 
-    void load();
+    void load(const ModelVersion override_version = ModelVersion::Unknown);
     PromptFeatures encode_prompt_audio(const std::string& id,
                                       const std::string& prompt_text,
                                       const std::vector<float>& mono_audio,
@@ -93,6 +93,7 @@ public:
     std::vector<float> convert_prompt_feat_to_reference_feat(
                                       const std::vector<float>& prompt_feat);
 
+    ModelVersion model_version() const;
     int sample_rate() const;
     int patch_size() const;
     int feat_dim() const;

--- a/include/voxcpm/server_common.h
+++ b/include/voxcpm/server_common.h
@@ -108,6 +108,13 @@ private:
                                                 int sample_rate);
     SynthesisResult synthesize_locked(const SynthesisRequest& request);
 
+    void prepare_combined_features(std::vector<float>& combined_features,
+                                  const int patch_size_value,
+                                  const int feat_dim_value,
+                                  PromptFeatures& mode_prompt,
+                                  const std::string& effective_text,
+                                  int& effective_prompt_audio_length);
+
     std::string model_path_;
     BackendType backend_type_;
     int threads_ = 4;

--- a/servers/voxcpm_server.cpp
+++ b/servers/voxcpm_server.cpp
@@ -187,22 +187,36 @@ RequestContext parse_request(const json& body, const Options& options) {
     if (body.contains("instructions") && !body["instructions"].is_null()) {
         const std::string instructions = body["instructions"].is_string() ? body["instructions"].get<std::string>() : "";
         if (!instructions.empty()) {
-            throw std::invalid_argument("`instructions` is not supported by VoxCPM v1");
+            if (options.model_name.length() < 7 || options.model_name.compare(0, 6, "voxcpm-")) {
+                throw std::invalid_argument("`model-name` has an unexpected value.");
+            }
+            switch (options.model_name[7]) {
+                case 0:
+                case 1:
+                    throw std::invalid_argument("`instructions` are not supported by VoxCPM versions less than 2");
+            }
+
+            switch (static_cast<char32_t>(ctx.input[0])) {
+                case '(':
+                case U'（':
+                    throw std::invalid_argument("instructions can not be provided both as a J.SON field and in the input text string");
+                default:
+                    ctx.input = "(" + instructions + ")" + ctx.input;
+            }
         }
     }
 
-    if (!body.contains("voice")) {
-        fail("`voice` is required");
-    }
-    if (body["voice"].is_string()) {
-        ctx.voice_id = body["voice"].get<std::string>();
-    } else if (body["voice"].is_object() && body["voice"].contains("id") && body["voice"]["id"].is_string()) {
-        ctx.voice_id = body["voice"]["id"].get<std::string>();
-    } else {
-        fail("`voice` must be a string or an object with an `id` field");
-    }
-    if (!is_valid_voice_id(ctx.voice_id)) {
-        fail("`voice` must be a valid voice id");
+    if (body.contains("voice")) {
+        if (body["voice"].is_string()) {
+            ctx.voice_id = body["voice"].get<std::string>();
+        } else if (body["voice"].is_object() && body["voice"].contains("id") && body["voice"]["id"].is_string()) {
+            ctx.voice_id = body["voice"]["id"].get<std::string>();
+        } else {
+            fail("`voice` must be a string or an object with an `id` field");
+        }
+        if (!is_valid_voice_id(ctx.voice_id)) {
+            fail("`voice` must be a valid voice id");
+        }
     }
 
     const std::string response_format = body.value("response_format", std::string("mp3"));
@@ -369,15 +383,13 @@ int main(int argc, char** argv) {
                 if (!req.form.has_field("id")) {
                     fail("Missing multipart field `id`");
                 }
-                if (!req.form.has_field("text")) {
-                    fail("Missing multipart field `text`");
-                }
+                // Reference audio file is currently still required for voice registration.
                 if (!req.form.has_file("audio")) {
                     fail("Missing multipart file `audio`");
                 }
 
                 const std::string id = req.form.get_field("id");
-                const std::string text = req.form.get_field("text");
+                const std::string text = req.form.has_field("text") ? req.form.get_field("text") : "";
                 if (!is_valid_voice_id(id)) {
                     fail("Invalid voice id");
                 }
@@ -389,7 +401,12 @@ int main(int argc, char** argv) {
                 const auto file = req.form.get_file("audio");
                 const DecodedAudio decoded = decode_audio_from_memory(file.content.data(), file.content.size());
                 const std::vector<float> mono = convert_to_mono(decoded);
-                PromptFeatures features = core.encode_prompt_audio(id, text, mono, decoded.sample_rate);
+                PromptFeatures features;
+                if (text.empty()) {
+                    features = core.encode_reference_audio(id, mono, decoded.sample_rate);
+                } else {
+                    features = core.encode_prompt_audio(id, text, mono, decoded.sample_rate);
+                }
                 voice_store.save_voice(features);
                 respond_json(res, 201, metadata_to_json(voice_store.load_metadata(id)));
             } catch (const std::exception& e) {
@@ -451,11 +468,13 @@ int main(int argc, char** argv) {
                 }
 
                 PromptFeatures prompt;
-                try {
-                    prompt = voice_store.load_voice(ctx.voice_id);
-                } catch (const std::exception&) {
-                    respond_error(res, 400, "Unknown voice id.", "invalid_request_error", "voice_not_found");
-                    return;
+                if (!ctx.voice_id.empty()) {
+                    try {
+                        prompt = voice_store.load_voice(ctx.voice_id);
+                    } catch (const std::exception&) {
+                        respond_error(res, 400, "Unknown voice id.", "invalid_request_error", "voice_not_found");
+                        return;
+                    }
                 }
 
                 if (ctx.sse) {

--- a/servers/voxcpm_server.cpp
+++ b/servers/voxcpm_server.cpp
@@ -499,6 +499,8 @@ int main(int argc, char** argv) {
                     }
                 }
 
+                SynthesisRequest request;
+
                 if (!ctx.continue_audio.empty()) {
                     std::vector<uint8_t> audio_file_data;
                     audio_file_data = base64_decode(ctx.continue_audio);
@@ -507,8 +509,12 @@ int main(int argc, char** argv) {
                         return;
                     }
                     const DecodedAudio audio_data = decode_audio_from_memory(audio_file_data.data(), audio_file_data.size());
-                    const std::vector<float> mono_waveform = convert_to_mono(audio_data);
-                    PromptFeatures extracted_features = core.encode_prompt_audio(ctx.voice_id, "", mono_waveform, audio_data.sample_rate);
+                    const std::vector<float> mono_waveform = resample_audio_to_rate(
+                        convert_to_mono(audio_data),
+                        audio_data.sample_rate,
+                        core.sample_rate()
+                    );
+                    PromptFeatures extracted_features = core.encode_prompt_audio(ctx.voice_id, "", mono_waveform, core.sample_rate());
                     if (extracted_features.prompt_feat.empty()) {
                         respond_error(res, 400, "Failed to parse audio data/features from continuation file.", "invalid_request_error", "bad_audio_file");
                         return;
@@ -562,7 +568,6 @@ int main(int argc, char** argv) {
                     return;
                 }
 
-                SynthesisRequest request;
                 request.text = ctx.input;
                 request.prompt = std::move(prompt);
                 request.has_uploaded_prompt_audio = !ctx.continue_audio.empty();

--- a/servers/voxcpm_server.cpp
+++ b/servers/voxcpm_server.cpp
@@ -41,6 +41,8 @@ struct RequestContext {
     double speed = 1.0;
     bool sse = false;
     int max_attempts;
+    std::string continue_audio;
+    std::string transcript;
 };
 
 [[noreturn]] void fail(const std::string& message) {
@@ -203,6 +205,24 @@ RequestContext parse_request(const json& body, const Options& options) {
                 default:
                     ctx.input = "(" + instructions + ")" + ctx.input;
             }
+        }
+    }
+
+    if (body.contains("continue_audio") || body.contains("transcript")) {
+        if (body.contains("continue_audio")) {
+            if (body["continue_audio"].is_null()) {
+                fail("`continue_audio` was specified with null value");
+            }
+            ctx.continue_audio = body["continue_audio"].get<std::string>();
+        }
+        if (body.contains("transcript")) {
+            if (body["transcript"].is_null()) {
+                fail("`transcript` was specified with null value");
+            }
+            ctx.transcript = body["transcript"].get<std::string>();
+        }
+        if (ctx.continue_audio.empty() || ctx.transcript.empty()) {
+            fail("`continue_audio` and `transcript` can only be used together");
         }
     }
 
@@ -401,13 +421,11 @@ int main(int argc, char** argv) {
                 const auto file = req.form.get_file("audio");
                 const DecodedAudio decoded = decode_audio_from_memory(file.content.data(), file.content.size());
                 const std::vector<float> mono = convert_to_mono(decoded);
-                PromptFeatures features;
-                if (text.empty()) {
-                    features = core.encode_reference_audio(id, mono, decoded.sample_rate);
-                } else {
-                    features = core.encode_prompt_audio(id, text, mono, decoded.sample_rate);
-                }
-                voice_store.save_voice(features);
+                PromptFeatures prompt_data = core.encode_prompt_audio(id, text, mono, decoded.sample_rate);
+                PromptFeatures ref_data = core.encode_reference_audio(id, mono, decoded.sample_rate);
+                prompt_data.reference_feat = std::move(ref_data.reference_feat);
+                prompt_data.reference_audio_length = ref_data.reference_audio_length;
+                voice_store.save_voice(prompt_data);
                 respond_json(res, 201, metadata_to_json(voice_store.load_metadata(id)));
             } catch (const std::exception& e) {
                 respond_error(res, 400, e.what(), "invalid_request_error", "bad_request");
@@ -475,6 +493,37 @@ int main(int argc, char** argv) {
                         respond_error(res, 400, "Unknown voice id.", "invalid_request_error", "voice_not_found");
                         return;
                     }
+                    if (prompt.prompt_feat.empty() && prompt.reference_feat.empty()) {
+                        respond_error(res, 400, "Registered voice does not contain any features!", "server_error", "bad_voice_data");
+                        return;
+                    }
+                }
+
+                if (!ctx.continue_audio.empty()) {
+                    std::vector<uint8_t> audio_file_data;
+                    audio_file_data = base64_decode(ctx.continue_audio);
+                    if (audio_file_data.empty()) {
+                        respond_error(res, 400, "Failed to decode audio continuation file.", "invalid_request_error", "bad_audio_file");
+                        return;
+                    }
+                    const DecodedAudio audio_data = decode_audio_from_memory(audio_file_data.data(), audio_file_data.size());
+                    const std::vector<float> mono_waveform = convert_to_mono(audio_data);
+                    PromptFeatures extracted_features = core.encode_prompt_audio(ctx.voice_id, "", mono_waveform, audio_data.sample_rate);
+                    if (extracted_features.prompt_feat.empty()) {
+                        respond_error(res, 400, "Failed to parse audio data/features from continuation file.", "invalid_request_error", "bad_audio_file");
+                        return;
+                    }
+                    if (prompt.reference_feat.empty()) {
+                        // Generate reference_feat for voices previously saved with only prompt_feat.
+                        // To do: save the newly generated reference_feat so it does not need to be regenerated each time.
+                        std::cerr << "No reference_feat in saved voice data! Creating reference_feat from prompt_feat.\n";
+                        prompt.reference_feat = core.convert_prompt_feat_to_reference_feat(prompt.prompt_feat);
+                        prompt.reference_audio_length = prompt.prompt_audio_length;
+                    }
+                    prompt.prompt_feat = std::move(extracted_features.prompt_feat);
+                    prompt.prompt_audio_length = extracted_features.prompt_audio_length;
+
+                    prompt.prompt_text = ctx.transcript;
                 }
 
                 if (ctx.sse) {
@@ -516,6 +565,7 @@ int main(int argc, char** argv) {
                 SynthesisRequest request;
                 request.text = ctx.input;
                 request.prompt = std::move(prompt);
+                request.has_uploaded_prompt_audio = !ctx.continue_audio.empty();
                 request.max_decode_steps = options.max_decode_steps;
                 request.retry_badcase = (ctx.max_attempts == 1 ? false : true);
                 request.retry_badcase_max_times = std::min(ctx.max_attempts, options.max_attempts);

--- a/servers/voxcpm_server.cpp
+++ b/servers/voxcpm_server.cpp
@@ -189,19 +189,19 @@ RequestContext parse_request(const json& body, const Options& options) {
     if (body.contains("instructions") && !body["instructions"].is_null()) {
         const std::string instructions = body["instructions"].is_string() ? body["instructions"].get<std::string>() : "";
         if (!instructions.empty()) {
-            if (options.model_name.length() < 7 || options.model_name.compare(0, 6, "voxcpm-")) {
-                throw std::invalid_argument("`model-name` has an unexpected value.");
+            if (options.model_name.compare(0, 7, "voxcpm-")) {
+                fail("`model` has an unexpected value. `instructions` must not be specified.");
             }
             switch (options.model_name[7]) {
                 case 0:
                 case 1:
-                    throw std::invalid_argument("`instructions` are not supported by VoxCPM versions less than 2");
+                    fail("`instructions` are not supported by VoxCPM versions less than 2");
             }
 
             switch (static_cast<char32_t>(ctx.input[0])) {
                 case '(':
                 case U'（':
-                    throw std::invalid_argument("instructions can not be provided both as a J.SON field and in the input text string");
+                    fail("instructions can not be provided both as a J.SON field and in the input text string");
                 default:
                     ctx.input = "(" + instructions + ")" + ctx.input;
             }

--- a/servers/voxcpm_server.cpp
+++ b/servers/voxcpm_server.cpp
@@ -22,7 +22,7 @@ struct Options {
     std::string host = "127.0.0.1";
     int port = 8080;
     std::string model_path;
-    std::string model_name;
+    ModelVersion model_version_override = ModelVersion::Unknown;
     std::string voice_dir;
     std::string api_key;
     BackendType backend = BackendType::CPU;
@@ -75,7 +75,8 @@ Options parse_args(int argc, char** argv) {
         } else if (arg == "--model-path") {
             options.model_path = require_value("--model-path");
         } else if (arg == "--model-name") {
-            options.model_name = require_value("--model-name");
+            options.model_version_override = parse_model_version_from_str(require_value("--model-name"));
+            if (options.model_version_override == ModelVersion::Unknown) fail("Invalid model string.");
         } else if (arg == "--voice-dir") {
             options.voice_dir = require_value("--voice-dir");
         } else if (arg == "--backend") {
@@ -96,7 +97,7 @@ Options parse_args(int argc, char** argv) {
             options.max_decode_steps = std::stoi(require_value("--max-decode-steps"));
         } else if (arg == "--help" || arg == "-h") {
             std::cout
-                << "Usage: voxcpm-server --model-path MODEL.gguf --model-name NAME --voice-dir DIR [options]\n"
+                << "Usage: voxcpm-server --model-path MODEL.gguf --voice-dir DIR [options]\n"
                 << "Options:\n"
                 << "  --host HOST           Default: 127.0.0.1\n"
                 << "  --port PORT           Default: 8080\n"
@@ -107,6 +108,7 @@ Options parse_args(int argc, char** argv) {
                 << "  --max-decode-steps N  Override per-request decode step cap, 0 keeps backend default\n"
                 << "  --output-sample-rate HZ  Optional output resample rate before encoding\n"
                 << "  --api-key KEY         Required unless --disable-auth\n"
+                << "  --model-name NAME     Override detection of model version based on signature in model file.\n"
                 << "  --disable-auth\n";
             std::exit(0);
         } else {
@@ -115,7 +117,6 @@ Options parse_args(int argc, char** argv) {
     }
 
     if (options.model_path.empty()) fail("--model-path is required");
-    if (options.model_name.empty()) fail("--model-name is required");
     if (options.voice_dir.empty()) fail("--voice-dir is required");
     if (!options.disable_auth && options.api_key.empty()) fail("--api-key is required unless --disable-auth is set");
     if (options.port < 1 || options.port > 65535) fail("--port must be between 1 and 65535");
@@ -170,13 +171,16 @@ bool authorize(const Options& options, const httplib::Request& req, httplib::Res
     return true;
 }
 
-RequestContext parse_request(const json& body, const Options& options) {
+RequestContext parse_request(const json& body, const Options& options,
+                             const ModelVersion running_model_version) {
     RequestContext ctx;
     if (!body.contains("model") || !body["model"].is_string()) {
         fail("`model` is required and must be a string");
     }
-    if (body["model"].get<std::string>() != options.model_name) {
-        fail("Requested model does not match the configured server model");
+    if (body.contains("model")) {
+        auto v = parse_model_version_from_str(body["model"].get<std::string>());
+        if (v == ModelVersion::Unknown) fail("Requested invalid model (string must match label)");
+        if (v != running_model_version) fail("Requested model does not match the configured server model");
     }
     if (!body.contains("input") || !body["input"].is_string()) {
         fail("`input` is required and must be a string");
@@ -189,12 +193,7 @@ RequestContext parse_request(const json& body, const Options& options) {
     if (body.contains("instructions") && !body["instructions"].is_null()) {
         const std::string instructions = body["instructions"].is_string() ? body["instructions"].get<std::string>() : "";
         if (!instructions.empty()) {
-            if (options.model_name.compare(0, 7, "voxcpm-")) {
-                fail("`model` has an unexpected value. `instructions` must not be specified.");
-            }
-            switch (options.model_name[7]) {
-                case 0:
-                case 1:
+            if (running_model_version < ModelVersion::v2_0) {
                     fail("`instructions` are not supported by VoxCPM versions less than 2");
             }
 
@@ -380,7 +379,7 @@ int main(int argc, char** argv) {
         const Options options = parse_args(argc, argv);
         ensure_voice_dir_exists(options.voice_dir);
         VoxCPMServiceCore core(options.model_path, options.backend, options.threads);
-        core.load();
+        core.load(options.model_version_override);
         VoiceStore voice_store(options.voice_dir);
         BoundedSynthesisQueue queue(options.max_queue);
 
@@ -466,7 +465,7 @@ int main(int argc, char** argv) {
 
             try {
                 const json body = json::parse(req.body);
-                const RequestContext ctx = parse_request(body, options);
+                const RequestContext ctx = parse_request(body, options, core.model_version());
                 const int response_sample_rate = effective_output_sample_rate(options, core.sample_rate());
 
                 if (!audio_response_format_supported(ctx.format)) {

--- a/src/audio-vae.cpp
+++ b/src/audio-vae.cpp
@@ -523,7 +523,8 @@ bool AudioVAE::load_decoder_weights(ggml_context* ggml_ctx_ptr) {
 bool AudioVAE::load_from_gguf(const std::string& gguf_path,
                               VoxCPMContext& weight_ctx,
                               VoxCPMContext& graph_ctx,
-                              VoxCPMBackend& backend) {
+                              VoxCPMBackend& backend,
+                              const ModelVersion override_version) {
     VOXCPM_UNUSED(weight_ctx);
     VOXCPM_UNUSED(graph_ctx);
 
@@ -531,15 +532,22 @@ bool AudioVAE::load_from_gguf(const std::string& gguf_path,
     if (!store->load_from_file(gguf_path, backend)) {
         return false;
     }
-    return load_from_store(store);
+    return load_from_store(store, override_version);
 }
 
-bool AudioVAE::load_from_store(const std::shared_ptr<VoxCPMWeightStore>& store) {
+bool AudioVAE::load_from_store(const std::shared_ptr<VoxCPMWeightStore>& store,
+                               const ModelVersion override_version) {
     if (!store || !store->owns_storage()) {
         return false;
     }
 
     shared_store_ = store;
+
+    std::string str_buff;
+    if (override_version == ModelVersion::Unknown) {
+        store->get_string("general.name", str_buff);
+        if ((config_.model_version = parse_model_version_from_str(str_buff)) == ModelVersion::Unknown) return false;
+    } else config_.model_version = override_version;
 
     uint32_t u32 = 0;
     const bool has_encoder_dim = store->get_u32("voxcpm_audio_vae_config_encoder_dim", u32);

--- a/src/audio-vae.cpp
+++ b/src/audio-vae.cpp
@@ -728,8 +728,7 @@ ggml_tensor* AudioVAE::causal_conv1d_dw_stateful(ggml_context* ctx,
             0
         );
 
-        const int64_t kernel = weight->ne[0];
-        ggml_tensor* result = conv1d_mul_mat_impl(ctx, weight, x_full, static_cast<int>(kernel), stride, dilation);
+        ggml_tensor* result = ggml_conv_1d_dw(ctx, weight, x_full, stride, 0, dilation);
 
         if (bias) result = ggml_add(ctx, result, reshape_bias_3d(ctx, bias));
 

--- a/src/audio-vae.cpp
+++ b/src/audio-vae.cpp
@@ -604,10 +604,15 @@ ggml_tensor* AudioVAE::causal_conv1d(ggml_context* ctx,
                                      int kernel_size,
                                      int stride,
                                      int dilation,
-                                     int padding) const {
+                                     int padding,
+                                     int output_padding) const {
     ggml_tensor* padded = x;
     if (padding > 0) {
-        padded = ggml_pad_ext(ctx, x, padding * 2, 0, 0, 0, 0, 0, 0, 0);
+        if (config_.model_version < ModelVersion::v2_0) {
+            padded = ggml_pad_ext(ctx, x, padding * 2, 0, 0, 0, 0, 0, 0, 0);
+        } else {
+            padded = ggml_pad_ext(ctx, x, padding * 2 - output_padding, 0, 0, 0, 0, 0, 0, 0);
+        }
     }
     ggml_tensor* result = conv1d_mul_mat_impl(ctx, weight, padded, kernel_size, stride, dilation);
     if (bias) {
@@ -624,11 +629,15 @@ ggml_tensor* AudioVAE::causal_conv1d_stateful(ggml_context* ctx,
                                               int stride,
                                               int dilation,
                                               int padding,
+                                              int output_padding,
                                               AudioVAEStreamingDecodeState& state,
                                               const std::string& state_name) const {
-    const int state_frames = padding * 2;
+    const int state_frames = config_.model_version < ModelVersion::v2_0
+        ? padding * 2
+        : padding * 2 - output_padding;
+
     if (state_frames <= 0) {
-        return causal_conv1d(ctx, x, weight, bias, kernel_size, stride, dilation, padding);
+        return causal_conv1d(ctx, x, weight, bias, kernel_size, stride, dilation, padding, output_padding);
     }
 
     ggml_tensor* prev = state.take_slot(state_frames, x->ne[1], state_name);
@@ -832,8 +841,9 @@ ggml_tensor* AudioVAE::residual_unit_forward(ggml_context* ctx,
     ggml_tensor* h = snake_activation(ctx, x, weights.snake1_alpha);
     h = causal_conv1d_dw(ctx, backend, h, weights.conv1_weight, weights.conv1_bias, 1, dilation, ((7 - 1) * dilation) / 2);
     h = snake_activation(ctx, h, weights.snake2_alpha);
-    h = causal_conv1d(ctx, h, weights.conv2_weight, weights.conv2_bias, 1, 1, 1, 0);
+    h = causal_conv1d(ctx, h, weights.conv2_weight, weights.conv2_bias, 1, 1, 1, 0, 0);
 
+    VOXCPM_ASSERT(x->ne[0] == h->ne[0]);
     if (x->ne[0] != h->ne[0]) {
         const int64_t target = std::min<int64_t>(x->ne[0], h->ne[0]);
         x = ggml_view_3d(ctx, x, target, x->ne[1], x->ne[2], x->nb[1], x->nb[2], 0);
@@ -861,7 +871,7 @@ ggml_tensor* AudioVAE::residual_unit_forward_stateful(ggml_context* ctx,
                                   state,
                                   state_name(state_prefix, "conv1"));
     h = snake_activation(ctx, h, weights.snake2_alpha);
-    h = causal_conv1d(ctx, h, weights.conv2_weight, weights.conv2_bias, 1, 1, 1, 0);
+    h = causal_conv1d(ctx, h, weights.conv2_weight, weights.conv2_bias, 1, 1, 1, 0, 0);
 
     if (x->ne[0] != h->ne[0]) {
         const int64_t target = std::min<int64_t>(x->ne[0], h->ne[0]);
@@ -888,7 +898,8 @@ ggml_tensor* AudioVAE::encoder_block_forward(ggml_context* ctx,
         stride * 2,
         stride,
         1,
-        static_cast<int>(std::ceil(stride / 2.0f)));
+        static_cast<int>(std::ceil(stride / 2.0f)),
+        (config_.model_version < ModelVersion::v2_0 ? 0 : stride % 2));
 }
 
 ggml_tensor* AudioVAE::decoder_block_forward(ggml_context* ctx,
@@ -990,7 +1001,7 @@ ggml_tensor* AudioVAE::sample_rate_condition_forward(
     if (weights.out_weight != nullptr) {
         VOXCPM_ASSERT(weights.out_snake_alpha != nullptr);
         conditioned = snake_activation(ctx, conditioned, weights.out_snake_alpha);
-        conditioned = causal_conv1d(ctx, conditioned, weights.out_weight, weights.out_bias, 1, 1, 1, 0);
+        conditioned = causal_conv1d(ctx, conditioned, weights.out_weight, weights.out_bias, 1, 1, 1, 0, 0);
     }
 
     return conditioned;
@@ -1000,13 +1011,13 @@ ggml_tensor* AudioVAE::encode_tensor(VoxCPMContext& ctx,
                                      const VoxCPMBackend& backend,
                                      ggml_tensor* audio) const {
     ggml_context* raw = ctx.raw_context();
-    ggml_tensor* x = causal_conv1d(raw, audio, weights_.encoder_block_0_weight, weights_.encoder_block_0_bias, 7, 1, 1, 3);
+    ggml_tensor* x = causal_conv1d(raw, audio, weights_.encoder_block_0_weight, weights_.encoder_block_0_bias, 7, 1, 1, 3, 0);
 
     for (int i = 0; i < config_.num_encoder_blocks(); ++i) {
         x = encoder_block_forward(raw, backend, x, weights_.encoder_blocks[static_cast<size_t>(i)], config_.encoder_rates[static_cast<size_t>(i)]);
     }
 
-    return causal_conv1d(raw, x, weights_.encoder_fc_mu_weight, weights_.encoder_fc_mu_bias, 3, 1, 1, 1);
+    return causal_conv1d(raw, x, weights_.encoder_fc_mu_weight, weights_.encoder_fc_mu_bias, 3, 1, 1, 1, 0);
 }
 
 ggml_tensor* AudioVAE::encode(VoxCPMContext& ctx,
@@ -1105,7 +1116,7 @@ ggml_tensor* AudioVAE::decode(VoxCPMContext& ctx,
     x = causal_conv1d(raw, x,
         weights_.decoder_model_1_weight,
         weights_.decoder_model_1_bias,
-        1, 1, 1, 0);
+        1, 1, 1, 0, 0);
 
     ggml_tensor* sr_bucket = nullptr;
     const bool has_sr_conditioning = std::any_of(weights_.decoder_blocks.begin(),
@@ -1133,7 +1144,7 @@ ggml_tensor* AudioVAE::decode(VoxCPMContext& ctx,
     x = causal_conv1d(raw, x,
                       weights_.decoder_final_conv_weight,
                       weights_.decoder_final_conv_bias,
-                      7, 1, 1, 3);
+                      7, 1, 1, 3, 0);
     x = ggml_tanh(raw, x);
     ggml_set_output(x);
     return x;
@@ -1166,7 +1177,7 @@ ggml_tensor* AudioVAE::decode_streaming(VoxCPMContext& ctx,
     x = causal_conv1d(raw, x,
         weights_.decoder_model_1_weight,
         weights_.decoder_model_1_bias,
-        1, 1, 1, 0);
+        1, 1, 1, 0, 0);
 
     ggml_tensor* sr_bucket = nullptr;
     const bool has_sr_conditioning = std::any_of(weights_.decoder_blocks.begin(),
@@ -1195,7 +1206,7 @@ ggml_tensor* AudioVAE::decode_streaming(VoxCPMContext& ctx,
     x = causal_conv1d_stateful(raw, x,
        weights_.decoder_final_conv_weight,
        weights_.decoder_final_conv_bias,
-       7, 1, 1, 3,
+       7, 1, 1, 3, 0,
        state, "decoder.final.conv");
     x = ggml_tanh(raw, x);
     ggml_set_output(x);

--- a/src/audio-vae.cpp
+++ b/src/audio-vae.cpp
@@ -1017,7 +1017,13 @@ ggml_tensor* AudioVAE::encode(VoxCPMContext& ctx,
 }
 
 bool AudioVAE::supports_streaming_decode(const VoxCPMBackend& backend) const {
-    return backend.type() == BackendType::CUDA && config_.depthwise && !config_.use_noise_block;
+    switch (backend.type()) {
+        case BackendType::CUDA   :
+        case BackendType::Vulkan :
+            break;
+        default: return false;
+    }
+    return config_.depthwise && !config_.use_noise_block;
 }
 
 bool AudioVAE::initialize_streaming_decode_state(VoxCPMBackend& backend,

--- a/src/audio_io.cpp
+++ b/src/audio_io.cpp
@@ -533,4 +533,30 @@ std::string base64_encode(const uint8_t* data, size_t size) {
     return out;
 }
 
+std::vector<uint8_t> base64_decode(const std::string& in) {
+    std::vector<uint8_t> out;
+    if (in.empty()) return out;
+
+    int val = 0;
+    int valb = 0;
+    for (char c : in) {
+        if (c == '=') break;
+        int idx = 0;
+        if (c >= 'A' && c <= 'Z') idx = c - 'A';
+        else if (c >= 'a' && c <= 'z') idx = c - 'a' + 26;
+        else if (c >= '0' && c <= '9') idx = c - '0' + 52;
+        else if (c == '+') idx = 62;
+        else if (c == '/') idx = 63;
+        else continue;
+
+        val = (val << 6) | idx;
+        valb += 6;
+        if (valb >= 8) {
+            out.push_back((val >> (valb - 8)) & 0xFF);
+            valb -= 8;
+        }
+    }
+    return out;
+}
+
 }  // namespace voxcpm

--- a/src/server_common.cpp
+++ b/src/server_common.cpp
@@ -941,22 +941,24 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
     if (request.prompt.reference_audio_length < 0) {
         fail("Voice metadata is invalid: reference_audio_length must be >= 0");
     }
-    if (!(request.prompt.prompt_feat.empty() && request.prompt.reference_feat.empty())) {
-        if (request.prompt.patch_size != patch_size_value) {
-            fail("Voice metadata patch_size does not match the loaded model");
+    if (!request.has_uploaded_prompt_audio) {
+        if (!(request.prompt.prompt_feat.empty() && request.prompt.reference_feat.empty())) {
+            if (request.prompt.patch_size != patch_size_value) {
+                fail("Voice metadata patch_size does not match the loaded model");
+            }
+            if (request.prompt.feat_dim != feat_dim_value) {
+                fail("Voice metadata feat_dim does not match the loaded model");
+            }
+            if (request.prompt.prompt_feat.size() != expected_prompt_feat_size) {
+                fail("Voice metadata is inconsistent with stored prompt features");
+            }
+            if (request.prompt.reference_feat.size() != expected_reference_feat_size) {
+                fail("Voice metadata is inconsistent with stored reference features");
+            }
         }
-        if (request.prompt.feat_dim != feat_dim_value) {
-            fail("Voice metadata feat_dim does not match the loaded model");
+        if ((request.prompt.prompt_audio_length == 0) != request.prompt.prompt_text.empty()) {
+            fail("Voice metadata is invalid: prompt_text must be provided iff prompt audio is present");
         }
-        if (request.prompt.prompt_feat.size() != expected_prompt_feat_size) {
-            fail("Voice metadata is inconsistent with stored prompt features");
-        }
-        if (request.prompt.reference_feat.size() != expected_reference_feat_size) {
-            fail("Voice metadata is inconsistent with stored reference features");
-        }
-    }
-    if ((request.prompt.prompt_audio_length == 0) != request.prompt.prompt_text.empty()) {
-        fail("Voice metadata is invalid: prompt_text must be provided iff prompt audio is present");
     }
     if (request.retry_badcase_max_times < 1) {
         fail("retry_badcase_max_times must be >= 1");
@@ -973,32 +975,72 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
 
     PromptFeatures mode_prompt; // Values should be initialised to zero.
     std::string effective_text = request.text;
-    if (test_for_control_prefix(request.text)) {
-        // Controllable Voice Cloning mode: use reference audio features.
-        if (!request.prompt.reference_feat.empty()) {
+    if (!request.prompt.id.empty()) {
+        // Voice specified: it must be used.
+        if (request.prompt.reference_feat.empty() && request.prompt.prompt_feat.empty()) {
+            fail("Selected voice is unusable (missing features).");
+        }
+        if (request.has_uploaded_prompt_audio) {
+            // Combined Mode: voice style + audio to continue.
+            // Reference for timbre + prompt for context (best cloning similarity).
+            std::cerr << "Mode: Combined (voice + continuation)\n";
             mode_prompt.reference_feat = request.prompt.reference_feat;
             mode_prompt.reference_audio_length = request.prompt.reference_audio_length;
-        } else if (!request.prompt.prompt_feat.empty()) {
-            // Registered voice was stored in Hi-Fi format-- adapt for controllable mode.
+            mode_prompt.prompt_feat = request.prompt.prompt_feat;
+            mode_prompt.prompt_audio_length = request.prompt.prompt_audio_length;
+
+            {
+                // Strip control prefix, if present, from the script to be spoken.
+                const auto [stripped_text, stripped] = strip_hifi_control_prefix(request.text);
+                if (stripped) effective_text = stripped_text;
+            }
+            {
+                // Strip control prefix, if present, from the reference (prompt_feat) transcript.
+                const auto [stripped_text, stripped] = strip_hifi_control_prefix(request.prompt.prompt_text);
+                if (stripped) mode_prompt.prompt_text = stripped_text;
+                else mode_prompt.prompt_text = request.prompt.prompt_text;
+            }
+        } else if (test_for_control_prefix(request.text)) {
+            // Controllable Voice Cloning: voice + control instructions.
+            // Isolated voice cloning from a reference clip.
+            std::cerr << "Mode: Controllable Voice Cloning\n";
             mode_prompt.reference_feat = request.prompt.prompt_feat;
             mode_prompt.reference_audio_length = request.prompt.prompt_audio_length;
+        } else {
+            // Hi-Fi Mode: only voice (use transcript from registration).
+            // Seamless continuation from prompt audio.
+            std::cerr << "Mode: Hi-Fi\n";
+            mode_prompt.prompt_feat = request.prompt.prompt_feat;
+            mode_prompt.prompt_audio_length = request.prompt.prompt_audio_length;
+            mode_prompt.prompt_text = request.prompt.prompt_text;
+            // I am not sure whether reference_feat should also be used in this mode.
+            mode_prompt.reference_feat = request.prompt.reference_feat;
+            mode_prompt.reference_audio_length = request.prompt.reference_audio_length;
+            // No need to strip control prefix-- we already tested out the possibility of one.
         }
-    } else if (!request.prompt.prompt_feat.empty()) {
-        // Hi-Fi / Ultimate Cloning mode: audio and transcript are required.
-        mode_prompt.prompt_feat = request.prompt.prompt_feat;
-        mode_prompt.prompt_audio_length = request.prompt.prompt_audio_length;
-        mode_prompt.prompt_text = request.prompt.prompt_text;
+    } else {
+        // No voice specified.
+        // Zero-shot / text-only synthesis.
+        if (request.has_uploaded_prompt_audio) {
+            // Continuation Mode.
+            std::cerr << "Mode: Continuation\n";
+            mode_prompt.prompt_feat = request.prompt.prompt_feat;
+            mode_prompt.prompt_audio_length = request.prompt.prompt_audio_length;
 
-        // Strip control prefix if present.
-        const auto [stripped_text, stripped] = strip_hifi_control_prefix(request.text);
-        if (stripped) {
-            effective_text = stripped_text;
-        }
-    } else if (!request.prompt.reference_feat.empty()) {
-        // Reference-only mode: voice cloning without control instructions.
-        mode_prompt.reference_feat = request.prompt.reference_feat;
-        mode_prompt.reference_audio_length = request.prompt.reference_audio_length;
-    }   // else (no reference or instructions): audio will be generated based on an arbitrary voice.
+            {
+                // Strip control prefix, if present, from the script to be spoken.
+                const auto [stripped_text, stripped] = strip_hifi_control_prefix(request.text);
+                if (stripped) effective_text = stripped_text;
+            }
+            {
+                // Strip control prefix, if present, from the reference (prompt_feat) transcript.
+                const auto [stripped_text, stripped] = strip_hifi_control_prefix(request.prompt.prompt_text);
+                if (stripped) mode_prompt.prompt_text = stripped_text;
+                else mode_prompt.prompt_text = request.prompt.prompt_text;
+            }
+        }   // else: Voice Design Mode: generate speech based on any (optional) control instructions.
+    }
+    std::cerr << "effective_text: \"" << effective_text << '"' << '\n';
     const bool has_prompt_audio = mode_prompt.prompt_audio_length > 0;
     const bool has_reference_audio = mode_prompt.reference_audio_length > 0;
     const std::vector<float>& active_features = has_prompt_audio ? mode_prompt.prompt_feat : mode_prompt.reference_feat;
@@ -1247,6 +1289,41 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
     }
 
     fail("Retry loop exhausted without producing an accepted sample");
+}
+
+std::vector<float> VoxCPMServiceCore::convert_prompt_feat_to_reference_feat(const std::vector<float>& prompt_feat) {
+    // Note: This may not work well for all voices. Particularly quiet voices.
+
+    const size_t floats_per_patch = static_cast<size_t>(this->patch_size()) * this->feat_dim();
+    const size_t num_patches = prompt_feat.size() / floats_per_patch;
+    if (num_patches == 0) return {};
+
+    // Find the first non-zero patch by checking the mean magnitude of the patch.
+    size_t first_nonzero = 0;
+    for (size_t i = 0; i < num_patches; ++i) {
+        const float* patch_data = prompt_feat.data() + i * floats_per_patch;
+        float sum = 0.0f;
+        for (size_t j = 0; j < floats_per_patch; ++j) {
+            sum += std::abs(patch_data[j]);
+        }
+        if (sum > static_cast<float>(floats_per_patch) * 1e-4f) {
+            first_nonzero = i;
+            break;
+        }
+    }
+
+    // If no padding was added, return a copy.
+    if (first_nonzero == 0) return prompt_feat;
+
+    // Construct right-padded features: [real_patches, zero_patches]
+    std::vector<float> ref_feat;
+    ref_feat.reserve(prompt_feat.size());
+    ref_feat.insert(ref_feat.end(),
+            prompt_feat.data() + first_nonzero * floats_per_patch,
+            prompt_feat.data() + num_patches * floats_per_patch);
+    ref_feat.insert(ref_feat.end(), first_nonzero * floats_per_patch, 0.0f);
+
+    return ref_feat;
 }
 
 int VoxCPMServiceCore::sample_rate() const {

--- a/src/server_common.cpp
+++ b/src/server_common.cpp
@@ -919,6 +919,32 @@ SynthesisResult VoxCPMServiceCore::synthesize(const SynthesisRequest& request) {
     return synthesize_locked(request);
 }
 
+inline void VoxCPMServiceCore::prepare_combined_features(std::vector<float>& combined_features,
+                          const int patch_size_value,
+                          const int feat_dim_value,
+                          PromptFeatures& mode_prompt,
+                          const std::string& effective_text,
+                          int& effective_prompt_audio_length) {
+        // Combined Mode: construct [Reference] + [Text Silence] + [Prompt] timeline
+        const size_t frame_stride = static_cast<size_t>(patch_size_value) * feat_dim_value;
+        const size_t ref_size = mode_prompt.reference_audio_length * frame_stride;
+        const size_t prompt_size = mode_prompt.prompt_audio_length * frame_stride;
+
+        // Match build_conditioning's token count: (prompt_text + target_text) + audio_start_token
+        const std::string main_text = mode_prompt.prompt_text + effective_text;
+        const int text_frames = static_cast<int>(split_tokenizer_->encode(main_text, false).size()) + 1;
+        const size_t silence_size = static_cast<size_t>(text_frames) * frame_stride;
+
+        combined_features.reserve(ref_size + silence_size + prompt_size);
+        combined_features.insert(combined_features.end(), mode_prompt.reference_feat.begin(), mode_prompt.reference_feat.end());
+        combined_features.insert(combined_features.end(), silence_size, 0.0f);
+        combined_features.insert(combined_features.end(), mode_prompt.prompt_feat.begin(), mode_prompt.prompt_feat.end());
+
+        // +2 accounts for reference start/end token zero-frames added by _make_ref_prefix
+        effective_prompt_audio_length = mode_prompt.reference_audio_length + 2 + text_frames + mode_prompt.prompt_audio_length;
+        std::cerr << "[tts] Combined Mode active features length: " << effective_prompt_audio_length << "\n";
+}
+
 SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& request) {
     if (request.text.empty()) {
         fail("Text input must not be empty");
@@ -1043,7 +1069,27 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
     std::cerr << "effective_text: \"" << effective_text << '"' << '\n';
     const bool has_prompt_audio = mode_prompt.prompt_audio_length > 0;
     const bool has_reference_audio = mode_prompt.reference_audio_length > 0;
-    const std::vector<float>& active_features = has_prompt_audio ? mode_prompt.prompt_feat : mode_prompt.reference_feat;
+
+
+    std::vector<float> combined_features;
+    int effective_prompt_audio_length = mode_prompt.prompt_audio_length;
+
+    const std::vector<float>* active_features_ptr = nullptr;
+    if (has_prompt_audio && has_reference_audio) {
+        prepare_combined_features(combined_features,
+                                  patch_size_value,
+                                  feat_dim_value,
+                                  mode_prompt,
+                                  effective_text,
+                                  effective_prompt_audio_length);
+        active_features_ptr = &combined_features;
+    } else {
+        active_features_ptr = has_prompt_audio ? &mode_prompt.prompt_feat : &mode_prompt.reference_feat;
+        std::cerr << "Using feature set: " << (has_prompt_audio ? "prompt_feat\n" : "reference_feat\n");
+    }
+    // The pointer could be used throughout the function if definitions for build_decode_feature_* are adjusted.
+    const std::vector<float>& active_features = *active_features_ptr;
+
 
     bool retry_badcase = request.retry_badcase;
     if (retry_badcase && request.chunk_callback) {
@@ -1058,7 +1104,6 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
               << " reference_audio_length=" << mode_prompt.reference_audio_length
               << " prompt_feat_size=" << active_features.size()
               << "\n";
-    const int prompt_audio_length = mode_prompt.prompt_audio_length;
     const int target_text_token_count =
         std::max<int>(1, static_cast<int>(split_tokenizer_->tokenize(effective_text).size()));
     const int natural_max_len =
@@ -1093,14 +1138,14 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
         const size_t frame_stride = static_cast<size_t>(patch_size_value) * feat_dim_value;
         const int context_frames =
             (has_prompt_audio && request.streaming_prefix_len > 1)
-                ? std::min(request.streaming_prefix_len - 1, prompt_audio_length)
+                ? std::min(request.streaming_prefix_len - 1, effective_prompt_audio_length)
                 : 0;
         const bool use_fallback_streaming_window = request.chunk_callback && !use_output_pool_timeline;
         if (use_fallback_streaming_window) {
             stream_recent_frames.reserve(static_cast<size_t>(request.streaming_prefix_len) * frame_stride);
         }
         if (use_fallback_streaming_window && context_frames > 0) {
-            const size_t context_offset = static_cast<size_t>(prompt_audio_length - context_frames) * frame_stride;
+            const size_t context_offset = static_cast<size_t>(effective_prompt_audio_length - context_frames) * frame_stride;
             stream_recent_frames.insert(stream_recent_frames.end(),
                                         active_features.begin() + static_cast<std::ptrdiff_t>(context_offset),
                                         active_features.end());
@@ -1173,7 +1218,7 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
             }
         }
         const int generated_frames = use_output_pool_timeline
-                                         ? std::max(0, state.audio_frame_count - prompt_audio_length)
+                                         ? std::max(0, state.audio_frame_count - effective_prompt_audio_length)
                                          : static_cast<int>(generated_steps.size() / frame_stride);
         std::cerr << "[tts] decode loop done generated_frames="
                   << generated_frames
@@ -1195,7 +1240,7 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
 
         int prepended_context_frames = 0;
         const int total_frames = (has_prompt_audio && request.streaming_prefix_len > 1
-                                      ? std::min(request.streaming_prefix_len - 1, prompt_audio_length)
+                                      ? std::min(request.streaming_prefix_len - 1, effective_prompt_audio_length)
                                       : 0) +
                                  generated_frames;
         const int total_patches = total_frames * patch_size_value;
@@ -1210,11 +1255,11 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
         const int decode_stateful_chunk_frames =
             stateful_audio_decode_chunk_frames(audio_vae_, patch_size_value);
         if (use_output_pool_timeline &&
-            state.audio_frame_count >= prompt_audio_length + generated_frames) {
+            state.audio_frame_count >= effective_prompt_audio_length + generated_frames) {
             const int frame_offset =
-                std::max(0, prompt_audio_length - std::min(request.streaming_prefix_len - 1, prompt_audio_length));
+                std::max(0, effective_prompt_audio_length - std::min(request.streaming_prefix_len - 1, effective_prompt_audio_length));
             prepended_context_frames = has_prompt_audio && request.streaming_prefix_len > 1
-                                           ? std::min(request.streaming_prefix_len - 1, prompt_audio_length)
+                                           ? std::min(request.streaming_prefix_len - 1, effective_prompt_audio_length)
                                            : 0;
             if (use_stateful_final_audio_decode) {
                 waveform = decode_audio_stateful_from_output_pool(audio_vae_,
@@ -1244,7 +1289,7 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
         } else {
             if (use_stateful_final_audio_decode) {
                 const std::vector<float> decode_frames = build_decode_feature_sequence(active_features,
-                                                                                       prompt_audio_length,
+                                                                                       effective_prompt_audio_length,
                                                                                        generated_steps,
                                                                                        request.streaming_prefix_len,
                                                                                        patch_size_value,
@@ -1265,7 +1310,7 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
             }
             if (waveform.empty()) {
                 latent = build_decode_latent_sequence(active_features,
-                                                      prompt_audio_length,
+                                                      effective_prompt_audio_length,
                                                       generated_steps,
                                                       request.streaming_prefix_len,
                                                       patch_size_value,

--- a/src/server_common.cpp
+++ b/src/server_common.cpp
@@ -998,7 +998,7 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
         // Reference-only mode: voice cloning without control instructions.
         mode_prompt.reference_feat = request.prompt.reference_feat;
         mode_prompt.reference_audio_length = request.prompt.reference_audio_length;
-    }   // else (no reference or instructions): audio will be generated based on an arbitraty voice.
+    }   // else (no reference or instructions): audio will be generated based on an arbitrary voice.
     const bool has_prompt_audio = mode_prompt.prompt_audio_length > 0;
     const bool has_reference_audio = mode_prompt.reference_audio_length > 0;
     const std::vector<float>& active_features = has_prompt_audio ? mode_prompt.prompt_feat : mode_prompt.reference_feat;

--- a/src/server_common.cpp
+++ b/src/server_common.cpp
@@ -791,7 +791,7 @@ VoxCPMServiceCore::VoxCPMServiceCore(std::string model_path, BackendType backend
       backend_type_(backend_type),
       threads_(threads) {}
 
-void VoxCPMServiceCore::load() {
+void VoxCPMServiceCore::load(const ModelVersion override_version) {
     std::lock_guard<std::mutex> lock(mutex_);
     if (loaded_) {
         return;
@@ -809,7 +809,7 @@ void VoxCPMServiceCore::load() {
     if (!runtime_.load_from_store(store_, *backend_)) {
         fail("Failed to initialize VoxCPM runtime from GGUF");
     }
-    if (!audio_vae_.load_from_store(store_)) {
+    if (!audio_vae_.load_from_store(store_, override_version)) {
         fail("Failed to initialize AudioVAE from GGUF");
     }
 
@@ -1368,6 +1368,9 @@ std::vector<float> VoxCPMServiceCore::convert_prompt_feat_to_reference_feat(cons
     return ref_feat;
 }
 
+ModelVersion VoxCPMServiceCore::model_version() const {
+    return audio_vae_.config().model_version;
+}
 int VoxCPMServiceCore::sample_rate() const {
     return audio_vae_.config().output_sample_rate();
 }

--- a/src/server_common.cpp
+++ b/src/server_common.cpp
@@ -1010,10 +1010,10 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
             // Combined Mode: voice style + audio to continue.
             // Reference for timbre + prompt for context.
             std::cerr << "Mode: Combined (voice + continuation)\n";
-            mode_prompt.reference_feat = request.prompt.reference_feat;
-            mode_prompt.reference_audio_length = request.prompt.reference_audio_length;
             mode_prompt.prompt_feat = request.prompt.prompt_feat;
             mode_prompt.prompt_audio_length = request.prompt.prompt_audio_length;
+            mode_prompt.reference_feat = request.prompt.reference_feat;
+            mode_prompt.reference_audio_length = request.prompt.reference_audio_length;
 
             // Strip control prefix, if present, from the script to be spoken.
             auto [stripped_text, stripped] = strip_hifi_control_prefix(request.text);

--- a/src/server_common.cpp
+++ b/src/server_common.cpp
@@ -1008,7 +1008,7 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
         }
         if (request.has_uploaded_prompt_audio) {
             // Combined Mode: voice style + audio to continue.
-            // Reference for timbre + prompt for context (best cloning similarity).
+            // Reference for timbre + prompt for context.
             std::cerr << "Mode: Combined (voice + continuation)\n";
             mode_prompt.reference_feat = request.prompt.reference_feat;
             mode_prompt.reference_audio_length = request.prompt.reference_audio_length;
@@ -1028,25 +1028,21 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
             }
         } else if (test_for_control_prefix(request.text)) {
             // Controllable Voice Cloning: voice + control instructions.
-            // Isolated voice cloning from a reference clip.
             std::cerr << "Mode: Controllable Voice Cloning\n";
             mode_prompt.reference_feat = request.prompt.prompt_feat;
             mode_prompt.reference_audio_length = request.prompt.prompt_audio_length;
         } else {
             // Hi-Fi Mode: only voice (use transcript from registration).
-            // Seamless continuation from prompt audio.
             std::cerr << "Mode: Hi-Fi\n";
             mode_prompt.prompt_feat = request.prompt.prompt_feat;
             mode_prompt.prompt_audio_length = request.prompt.prompt_audio_length;
             mode_prompt.prompt_text = request.prompt.prompt_text;
-            // I am not sure whether reference_feat should also be used in this mode.
             mode_prompt.reference_feat = request.prompt.reference_feat;
             mode_prompt.reference_audio_length = request.prompt.reference_audio_length;
             // No need to strip control prefix-- we already tested out the possibility of one.
         }
     } else {
-        // No voice specified.
-        // Zero-shot / text-only synthesis.
+        // No voice specified-- zero-shot / text-only synthesis.
         if (request.has_uploaded_prompt_audio) {
             // Continuation Mode.
             std::cerr << "Mode: Continuation\n";
@@ -1087,7 +1083,6 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
         active_features_ptr = has_prompt_audio ? &mode_prompt.prompt_feat : &mode_prompt.reference_feat;
         std::cerr << "Using feature set: " << (has_prompt_audio ? "prompt_feat\n" : "reference_feat\n");
     }
-    // The pointer could be used throughout the function if definitions for build_decode_feature_* are adjusted.
     const std::vector<float>& active_features = *active_features_ptr;
 
 

--- a/src/server_common.cpp
+++ b/src/server_common.cpp
@@ -1038,6 +1038,7 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
             mode_prompt.prompt_feat = request.prompt.prompt_feat;
             mode_prompt.prompt_audio_length = request.prompt.prompt_audio_length;
             mode_prompt.prompt_text = request.prompt.prompt_text;
+            // It is ok if reference_feat is empty and audio_length is zero.
             mode_prompt.reference_feat = request.prompt.reference_feat;
             mode_prompt.reference_audio_length = request.prompt.reference_audio_length;
             // No need to strip control prefix-- we already tested out the possibility of one.

--- a/src/server_common.cpp
+++ b/src/server_common.cpp
@@ -76,6 +76,14 @@ size_t skip_ascii_whitespace(const std::string& text, size_t pos) {
     return pos;
 }
 
+static inline bool test_for_control_prefix(const std::string& text) {
+    const size_t start = skip_ascii_whitespace(text, 0);
+    if (
+               text.compare(start, 1, "(") == 0
+            || text.compare(start, 3, "（") == 0
+    ) return true;
+    return false;
+}
 std::pair<std::string, bool> strip_hifi_control_prefix(const std::string& text) {
     const size_t start = skip_ascii_whitespace(text, 0);
     if (start >= text.size()) {
@@ -933,17 +941,19 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
     if (request.prompt.reference_audio_length < 0) {
         fail("Voice metadata is invalid: reference_audio_length must be >= 0");
     }
-    if (request.prompt.patch_size != patch_size_value) {
-        fail("Voice metadata patch_size does not match the loaded model");
-    }
-    if (request.prompt.feat_dim != feat_dim_value) {
-        fail("Voice metadata feat_dim does not match the loaded model");
-    }
-    if (request.prompt.prompt_feat.size() != expected_prompt_feat_size) {
-        fail("Voice metadata is inconsistent with stored prompt features");
-    }
-    if (request.prompt.reference_feat.size() != expected_reference_feat_size) {
-        fail("Voice metadata is inconsistent with stored reference features");
+    if (!(request.prompt.prompt_feat.empty() && request.prompt.reference_feat.empty())) {
+        if (request.prompt.patch_size != patch_size_value) {
+            fail("Voice metadata patch_size does not match the loaded model");
+        }
+        if (request.prompt.feat_dim != feat_dim_value) {
+            fail("Voice metadata feat_dim does not match the loaded model");
+        }
+        if (request.prompt.prompt_feat.size() != expected_prompt_feat_size) {
+            fail("Voice metadata is inconsistent with stored prompt features");
+        }
+        if (request.prompt.reference_feat.size() != expected_reference_feat_size) {
+            fail("Voice metadata is inconsistent with stored reference features");
+        }
     }
     if ((request.prompt.prompt_audio_length == 0) != request.prompt.prompt_text.empty()) {
         fail("Voice metadata is invalid: prompt_text must be provided iff prompt audio is present");
@@ -961,30 +971,52 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
     runtime_.reset_request_state();
     backend_->reset_request_state();
 
-    const bool has_prompt_audio = request.prompt.prompt_audio_length > 0;
-    const bool has_reference_audio = request.prompt.reference_audio_length > 0;
+    PromptFeatures mode_prompt; // Values should be initialised to zero.
     std::string effective_text = request.text;
-    if (has_prompt_audio) {
+    if (test_for_control_prefix(request.text)) {
+        // Controllable Voice Cloning mode: use reference audio features.
+        if (!request.prompt.reference_feat.empty()) {
+            mode_prompt.reference_feat = request.prompt.reference_feat;
+            mode_prompt.reference_audio_length = request.prompt.reference_audio_length;
+        } else if (!request.prompt.prompt_feat.empty()) {
+            // Registered voice was stored in Hi-Fi format-- adapt for controllable mode.
+            mode_prompt.reference_feat = request.prompt.prompt_feat;
+            mode_prompt.reference_audio_length = request.prompt.prompt_audio_length;
+        }
+    } else if (!request.prompt.prompt_feat.empty()) {
+        // Hi-Fi / Ultimate Cloning mode: audio and transcript are required.
+        mode_prompt.prompt_feat = request.prompt.prompt_feat;
+        mode_prompt.prompt_audio_length = request.prompt.prompt_audio_length;
+        mode_prompt.prompt_text = request.prompt.prompt_text;
+
+        // Strip control prefix if present.
         const auto [stripped_text, stripped] = strip_hifi_control_prefix(request.text);
         if (stripped) {
-            std::cerr << "[tts] Hi-Fi mode ignores control instructions; stripping the leading parenthesized prefix.\n";
             effective_text = stripped_text;
         }
-    }
+    } else if (!request.prompt.reference_feat.empty()) {
+        // Reference-only mode: voice cloning without control instructions.
+        mode_prompt.reference_feat = request.prompt.reference_feat;
+        mode_prompt.reference_audio_length = request.prompt.reference_audio_length;
+    }   // else (no reference or instructions): audio will be generated based on an arbitraty voice.
+    const bool has_prompt_audio = mode_prompt.prompt_audio_length > 0;
+    const bool has_reference_audio = mode_prompt.reference_audio_length > 0;
+    const std::vector<float>& active_features = has_prompt_audio ? mode_prompt.prompt_feat : mode_prompt.reference_feat;
+
     bool retry_badcase = request.retry_badcase;
     if (retry_badcase && request.chunk_callback) {
         std::cerr << "[tts] retry_badcase is not supported with streaming chunks; disabling retries.\n";
         retry_badcase = false;
     }
     const PreparedConditioning prepared =
-        build_conditioning(*split_tokenizer_, effective_text, request.prompt, patch_size_value, feat_dim_value);
+        build_conditioning(*split_tokenizer_, effective_text, mode_prompt, patch_size_value, feat_dim_value);
     const int seq_len = static_cast<int>(prepared.full_text_tokens.size());
     std::cerr << "[tts] synth start seq_len=" << prepared.full_text_tokens.size()
-              << " prompt_audio_length=" << request.prompt.prompt_audio_length
-              << " reference_audio_length=" << request.prompt.reference_audio_length
-              << " prompt_feat_size=" << request.prompt.prompt_feat.size()
+              << " prompt_audio_length=" << mode_prompt.prompt_audio_length
+              << " reference_audio_length=" << mode_prompt.reference_audio_length
+              << " prompt_feat_size=" << active_features.size()
               << "\n";
-    const int prompt_audio_length = request.prompt.prompt_audio_length;
+    const int prompt_audio_length = mode_prompt.prompt_audio_length;
     const int target_text_token_count =
         std::max<int>(1, static_cast<int>(split_tokenizer_->tokenize(effective_text).size()));
     const int natural_max_len =
@@ -1028,8 +1060,8 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
         if (use_fallback_streaming_window && context_frames > 0) {
             const size_t context_offset = static_cast<size_t>(prompt_audio_length - context_frames) * frame_stride;
             stream_recent_frames.insert(stream_recent_frames.end(),
-                                        request.prompt.prompt_feat.begin() + static_cast<std::ptrdiff_t>(context_offset),
-                                        request.prompt.prompt_feat.end());
+                                        active_features.begin() + static_cast<std::ptrdiff_t>(context_offset),
+                                        active_features.end());
         }
 
         for (int step = 0; step < max_len; ++step) {
@@ -1169,7 +1201,7 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
             }
         } else {
             if (use_stateful_final_audio_decode) {
-                const std::vector<float> decode_frames = build_decode_feature_sequence(request.prompt.prompt_feat,
+                const std::vector<float> decode_frames = build_decode_feature_sequence(active_features,
                                                                                        prompt_audio_length,
                                                                                        generated_steps,
                                                                                        request.streaming_prefix_len,
@@ -1190,7 +1222,7 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
                 prepended_context_frames = 0;
             }
             if (waveform.empty()) {
-                latent = build_decode_latent_sequence(request.prompt.prompt_feat,
+                latent = build_decode_latent_sequence(active_features,
                                                       prompt_audio_length,
                                                       generated_steps,
                                                       request.streaming_prefix_len,

--- a/src/server_common.cpp
+++ b/src/server_common.cpp
@@ -585,6 +585,7 @@ bool should_use_output_pool_timeline(const VoxCPMDecodeState& state, bool has_re
 
 std::vector<float> build_decode_feature_sequence(const std::vector<float>& prompt_feat,
                                                  int prompt_audio_length,
+                                                 int total_audio_length,
                                                  const std::vector<float>& generated_steps,
                                                  int streaming_prefix_len,
                                                  int patch_size,
@@ -599,7 +600,8 @@ std::vector<float> build_decode_feature_sequence(const std::vector<float>& promp
     std::vector<float> decode_frames;
     decode_frames.reserve(static_cast<size_t>(context_frames) * frame_stride + generated_steps.size());
     if (context_frames > 0) {
-        const size_t context_offset = static_cast<size_t>(prompt_audio_length - context_frames) * frame_stride;
+        // Seed VAE with prompt audio.
+        const size_t context_offset = static_cast<size_t>(total_audio_length - context_frames) * frame_stride;
         decode_frames.insert(decode_frames.end(),
                              prompt_feat.begin() + static_cast<std::ptrdiff_t>(context_offset),
                              prompt_feat.end());
@@ -614,6 +616,7 @@ std::vector<float> build_decode_feature_sequence(const std::vector<float>& promp
 
 std::vector<float> build_decode_latent_sequence(const std::vector<float>& prompt_feat,
                                                 int prompt_audio_length,
+                                                int total_audio_length,
                                                 const std::vector<float>& generated_steps,
                                                 int streaming_prefix_len,
                                                 int patch_size,
@@ -650,7 +653,7 @@ std::vector<float> build_decode_latent_sequence(const std::vector<float>& prompt
     };
 
     if (context_frames > 0) {
-        const size_t context_offset = static_cast<size_t>(prompt_audio_length - context_frames) * frame_stride;
+        const size_t context_offset = static_cast<size_t>(total_audio_length - context_frames) * frame_stride;
         write_patch_major_frames(prompt_feat.data() + static_cast<std::ptrdiff_t>(context_offset), context_frames, 0);
     }
     write_patch_major_frames(generated_steps.data(), generated_frames, context_frames);
@@ -1128,8 +1131,9 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
         const size_t frame_stride = static_cast<size_t>(patch_size_value) * feat_dim_value;
         const int context_frames =
             (has_prompt_audio && request.streaming_prefix_len > 1)
-                ? std::min(request.streaming_prefix_len - 1, effective_prompt_audio_length)
+                ? std::min(request.streaming_prefix_len - 1, mode_prompt.prompt_audio_length)
                 : 0;
+
         const bool use_fallback_streaming_window = request.chunk_callback && !use_output_pool_timeline;
         if (use_fallback_streaming_window) {
             stream_recent_frames.reserve(static_cast<size_t>(request.streaming_prefix_len) * frame_stride);
@@ -1208,7 +1212,7 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
             }
         }
         const int generated_frames = use_output_pool_timeline
-                                         ? std::max(0, state.audio_frame_count - effective_prompt_audio_length)
+                                         ? std::max(0, state.audio_frame_count - mode_prompt.prompt_audio_length)
                                          : static_cast<int>(generated_steps.size() / frame_stride);
         std::cerr << "[tts] decode loop done generated_frames="
                   << generated_frames
@@ -1230,7 +1234,7 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
 
         int prepended_context_frames = 0;
         const int total_frames = (has_prompt_audio && request.streaming_prefix_len > 1
-                                      ? std::min(request.streaming_prefix_len - 1, effective_prompt_audio_length)
+                                      ? std::min(request.streaming_prefix_len - 1, mode_prompt.prompt_audio_length)
                                       : 0) +
                                  generated_frames;
         const int total_patches = total_frames * patch_size_value;
@@ -1245,11 +1249,11 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
         const int decode_stateful_chunk_frames =
             stateful_audio_decode_chunk_frames(audio_vae_, patch_size_value);
         if (use_output_pool_timeline &&
-            state.audio_frame_count >= effective_prompt_audio_length + generated_frames) {
+            state.audio_frame_count >= mode_prompt.prompt_audio_length + generated_frames) {
             const int frame_offset =
-                std::max(0, effective_prompt_audio_length - std::min(request.streaming_prefix_len - 1, effective_prompt_audio_length));
+                std::max(0, effective_prompt_audio_length - std::min(request.streaming_prefix_len - 1, mode_prompt.prompt_audio_length));
             prepended_context_frames = has_prompt_audio && request.streaming_prefix_len > 1
-                                           ? std::min(request.streaming_prefix_len - 1, effective_prompt_audio_length)
+                                           ? std::min(request.streaming_prefix_len - 1, mode_prompt.prompt_audio_length)
                                            : 0;
             if (use_stateful_final_audio_decode) {
                 waveform = decode_audio_stateful_from_output_pool(audio_vae_,
@@ -1279,6 +1283,7 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
         } else {
             if (use_stateful_final_audio_decode) {
                 const std::vector<float> decode_frames = build_decode_feature_sequence(active_features,
+                                                                                       mode_prompt.prompt_audio_length,
                                                                                        effective_prompt_audio_length,
                                                                                        generated_steps,
                                                                                        request.streaming_prefix_len,
@@ -1300,6 +1305,7 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
             }
             if (waveform.empty()) {
                 latent = build_decode_latent_sequence(active_features,
+                                                      mode_prompt.prompt_audio_length,
                                                       effective_prompt_audio_length,
                                                       generated_steps,
                                                       request.streaming_prefix_len,

--- a/src/server_common.cpp
+++ b/src/server_common.cpp
@@ -935,14 +935,15 @@ inline void VoxCPMServiceCore::prepare_combined_features(std::vector<float>& com
         const int text_frames = static_cast<int>(split_tokenizer_->encode(main_text, false).size()) + 1;
         const size_t silence_size = static_cast<size_t>(text_frames) * frame_stride;
 
-        combined_features.reserve(ref_size + silence_size + prompt_size);
+        combined_features.reserve(ref_size + silence_size + prompt_size + (2 * frame_stride));
+        combined_features.insert(combined_features.end(), frame_stride, 0.0f);  // Zero-frame.
         combined_features.insert(combined_features.end(), mode_prompt.reference_feat.begin(), mode_prompt.reference_feat.end());
+        combined_features.insert(combined_features.end(), frame_stride, 0.0f);  // Zero-frame.
         combined_features.insert(combined_features.end(), silence_size, 0.0f);
         combined_features.insert(combined_features.end(), mode_prompt.prompt_feat.begin(), mode_prompt.prompt_feat.end());
 
-        // +2 accounts for reference start/end token zero-frames added by _make_ref_prefix
+        // +2 accounts for start/end zero-frames encapsulating reference_feat.
         effective_prompt_audio_length = mode_prompt.reference_audio_length + 2 + text_frames + mode_prompt.prompt_audio_length;
-        std::cerr << "[tts] Combined Mode active features length: " << effective_prompt_audio_length << "\n";
 }
 
 SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& request) {

--- a/src/server_common.cpp
+++ b/src/server_common.cpp
@@ -1015,17 +1015,14 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
             mode_prompt.prompt_feat = request.prompt.prompt_feat;
             mode_prompt.prompt_audio_length = request.prompt.prompt_audio_length;
 
-            {
-                // Strip control prefix, if present, from the script to be spoken.
-                const auto [stripped_text, stripped] = strip_hifi_control_prefix(request.text);
-                if (stripped) effective_text = stripped_text;
-            }
-            {
-                // Strip control prefix, if present, from the reference (prompt_feat) transcript.
-                const auto [stripped_text, stripped] = strip_hifi_control_prefix(request.prompt.prompt_text);
-                if (stripped) mode_prompt.prompt_text = stripped_text;
-                else mode_prompt.prompt_text = request.prompt.prompt_text;
-            }
+            // Strip control prefix, if present, from the script to be spoken.
+            auto [stripped_text, stripped] = strip_hifi_control_prefix(request.text);
+            if (stripped) effective_text = stripped_text;
+
+            // Strip control prefix, if present, from the reference (prompt_feat) transcript.
+            std::tie(stripped_text, stripped) = strip_hifi_control_prefix(request.prompt.prompt_text);
+            if (stripped) mode_prompt.prompt_text = stripped_text;
+            else mode_prompt.prompt_text = request.prompt.prompt_text;
         } else if (test_for_control_prefix(request.text)) {
             // Controllable Voice Cloning: voice + control instructions.
             std::cerr << "Mode: Controllable Voice Cloning\n";
@@ -1049,17 +1046,14 @@ SynthesisResult VoxCPMServiceCore::synthesize_locked(const SynthesisRequest& req
             mode_prompt.prompt_feat = request.prompt.prompt_feat;
             mode_prompt.prompt_audio_length = request.prompt.prompt_audio_length;
 
-            {
-                // Strip control prefix, if present, from the script to be spoken.
-                const auto [stripped_text, stripped] = strip_hifi_control_prefix(request.text);
-                if (stripped) effective_text = stripped_text;
-            }
-            {
-                // Strip control prefix, if present, from the reference (prompt_feat) transcript.
-                const auto [stripped_text, stripped] = strip_hifi_control_prefix(request.prompt.prompt_text);
-                if (stripped) mode_prompt.prompt_text = stripped_text;
-                else mode_prompt.prompt_text = request.prompt.prompt_text;
-            }
+            // Strip control prefix, if present, from the script to be spoken.
+            auto [stripped_text, stripped] = strip_hifi_control_prefix(request.text);
+            if (stripped) effective_text = stripped_text;
+
+            // Strip control prefix, if present, from the reference (prompt_feat) transcript.
+            std::tie(stripped_text, stripped) = strip_hifi_control_prefix(request.prompt.prompt_text);
+            if (stripped) mode_prompt.prompt_text = stripped_text;
+            else mode_prompt.prompt_text = request.prompt.prompt_text;
         }   // else: Voice Design Mode: generate speech based on any (optional) control instructions.
     }
     std::cerr << "effective_text: \"" << effective_text << '"' << '\n';


### PR DESCRIPTION
Previously, only the mode with the most names was supported. This commit adds support for several other modes.

- Voices can now be registered either with or without a transcript.
- Instructions (voice control) can now be requested either with the J.SON field or in the text string.
- Speech can be generated with or without instructions regardless of how a voice was registered.
- Speech can be generated with or without instructions without specifying any voice in the request.

There may still be some bugs with this but it seems to work so far. I will continue testing.