### PR TITLE
server: expose --inference-timesteps

### DIFF
--- a/servers/voxcpm_server.cpp
+++ b/servers/voxcpm_server.cpp
@@ -31,6 +31,7 @@ struct Options {
     int max_attempts = 3;
     int output_sample_rate = 0;
     int max_decode_steps = 0;
+    int inference_timesteps = 10;
     bool disable_auth = false;
 };
 
@@ -92,6 +93,8 @@ Options parse_args(int argc, char** argv) {
             options.output_sample_rate = std::stoi(require_value("--output-sample-rate"));
         } else if (arg == "--max-decode-steps") {
             options.max_decode_steps = std::stoi(require_value("--max-decode-steps"));
+        } else if (arg == "--inference-timesteps") {
+            options.inference_timesteps = std::stoi(require_value("--inference-timesteps"));
         } else if (arg == "--help" || arg == "-h") {
             std::cout
                 << "Usage: voxcpm-server --model-path MODEL.gguf --model-name NAME --voice-dir DIR [options]\n"
@@ -103,6 +106,7 @@ Options parse_args(int argc, char** argv) {
                 << "  --max-queue N         Default: 8\n"
                 << "  --max-attempts N      Default: 3\n"
                 << "  --max-decode-steps N  Override per-request decode step cap, 0 keeps backend default\n"
+                << "  --inference-timesteps N  Diffusion steps per chunk. Default: 10. Lower is faster\n"
                 << "  --output-sample-rate HZ  Optional output resample rate before encoding\n"
                 << "  --api-key KEY         Required unless --disable-auth\n"
                 << "  --disable-auth\n";
@@ -123,6 +127,9 @@ Options parse_args(int argc, char** argv) {
     if (options.output_sample_rate < 0) fail("--output-sample-rate must be >= 0");
     if (options.max_decode_steps < 0 || options.max_decode_steps > 2000) {
         fail("--max-decode-steps must be between 0 and 2000");
+    }
+    if (options.inference_timesteps < 1 || options.inference_timesteps > 100) {
+        fail("--inference-timesteps must be between 1 and 100");
     }
     return options;
 }
@@ -464,6 +471,7 @@ int main(int argc, char** argv) {
                     request.text = ctx.input;
                     request.prompt = std::move(prompt);
                     request.max_decode_steps = options.max_decode_steps;
+                    request.inference_timesteps = options.inference_timesteps;
                     request.chunk_callback = [&](const std::vector<float>& chunk_waveform) {
                         const std::vector<float> prepared = prepare_response_waveform(chunk_waveform,
                                                                                       core.sample_rate(),
@@ -498,6 +506,7 @@ int main(int argc, char** argv) {
                 request.text = ctx.input;
                 request.prompt = std::move(prompt);
                 request.max_decode_steps = options.max_decode_steps;
+                request.inference_timesteps = options.inference_timesteps;
                 request.retry_badcase = (ctx.max_attempts == 1 ? false : true);
                 request.retry_badcase_max_times = std::min(ctx.max_attempts, options.max_attempts);
                 SynthesisResult result = core.synthesize(request);


### PR DESCRIPTION
## What

`voxcpm-server` has no way to set the number of diffusion steps. `voxcpm_tts` has had
`--inference-timesteps` all along, and `SynthesisRequest::inference_timesteps` already
reaches the CFM decoder through `server_common.cpp` — but nothing ever assigns it, so the
server is pinned to the struct default of 10.

This adds `--inference-timesteps N`, mirroring `--max-decode-steps` exactly: one option
field, one parser arm, one help line, one bound check, and an assignment at each of the
two `SynthesisRequest` construction sites (the SSE path and the buffered path).

## Why

After `--threads`, it is the largest lever on RTF, and the only one that can bring a CPU
build near real time.

Measured on an M3 Max, CPU backend, `voxcpm2-q4_k-audiovae-f16`, a 38-character Mandarin
sentence, `Full pipeline` RTF as the binary reports it:

| threads (text-only, ts=10) | RTF |
|---|---|
| 4 | 2.438 |
| 8 | 1.508 |
| **12** | **1.201** |
| 16 | 1.433 |

| ts (reference-mode cloning, threads=12) | RTF |
|---|---|
| 10 | — |
| 6 | 1.204 |
| 5 | 1.036 |
| 4 | 0.994 |
| 3 | 0.960 |

Dropping the server from ts=10 to ts=6 took its end-to-end RTF from ~1.5 to ~1.12 with no
loss of intelligibility: I transcribed the synthesized audio with an ASR model and compared
it against the input text, and the score was unchanged (94.4%). By ear, ts=3 is not usable
and ts=4 is close to the edge, so 6 is where I left it — but that trade belongs to the
operator, and right now they cannot make it at all without patching the source.

Two notes for reviewers:

- Range is 1..100 and the backend default of 10 is preserved, so existing deployments are
  unaffected.
- Intelligibility is not naturalness. ASR still scored 91.7% at ts=3, where the audio is
  plainly bad. The table above is not an argument for any particular default.

## Test

Built and run as a resident service. `--help` lists the flag; the process reports the
value; synthesis at ts=6 verified correct against ASR over three runs.
