### PR TITLE
Streamline backend-dependent VAE logic.

### DIFF
--- a/src/audio-vae.cpp
+++ b/src/audio-vae.cpp
@@ -647,43 +647,29 @@ ggml_tensor* AudioVAE::causal_conv1d_dw(ggml_context* ctx,
                                         int dilation,
                                         int padding) const {
 
-    if (backend.type() == BackendType::Vulkan) {
-        // The GGML library in use does not define ggml_map_custom3 for Vulkan.
-        // This causes silent audio output (or occasionally popping noises).
-        // Replace unsupported ggml_map_custom3 call with standard depthwise convolution.
+    if (backend.type() == BackendType::CPU) {
+        // Use ggml_map_custom3 (only supported on CPU).
+        auto op = std::make_unique<AudioVAEDepthwiseConvOpData>();
+        op->stride = stride;
+        op->dilation = dilation;
+        op->padding = padding;
 
-        ggml_tensor* padded = x;
-        if (padding > 0) padded = ggml_pad_ext(ctx, x, padding * 2, 0, 0, 0, 0, 0, 0, 0);
-        padded = ggml_cont(ctx, padded);
-
-        ggml_tensor* result;
-        if (!(result = ggml_conv_1d_dw(ctx, weight, padded, stride, 0, dilation))) return nullptr;
-
-        if (bias) result = ggml_add(ctx, result, reshape_bias_3d(ctx, bias));
-        return ggml_cont(ctx, result);
+        AudioVAEDepthwiseConvOpData* op_ptr = op.get();
+        depthwise_ops_.push_back(std::move(op));
+        return ggml_map_custom3(ctx, x, weight, bias, depthwise_conv_custom, GGML_N_TASKS_MAX, op_ptr);
     }
+    // The GGML library in use does not define ggml_map_custom3 for other back-ends.
+    // Use standard depthwise convolution instead of ggml_map_custom3.
 
-    if (backend.type() == BackendType::CUDA) {
-        ggml_tensor* padded = x;
-        if (padding > 0) {
-            padded = ggml_pad_ext(ctx, x, padding * 2, 0, 0, 0, 0, 0, 0, 0);
-        }
+    ggml_tensor* padded = x;
+    if (padding > 0) padded = ggml_pad_ext(ctx, x, padding * 2, 0, 0, 0, 0, 0, 0, 0);
+    if (backend.type() == BackendType::Vulkan) padded = ggml_cont(ctx, padded);
 
-        ggml_tensor* result = ggml_conv_1d_dw(ctx, weight, padded, stride, 0, dilation);
-        if (bias) {
-            result = ggml_add(ctx, result, reshape_bias_3d(ctx, bias));
-        }
-        return ggml_cont(ctx, result);
-    }
+    ggml_tensor* result;
+    if (!(result = ggml_conv_1d_dw(ctx, weight, padded, stride, 0, dilation))) return nullptr;
 
-    auto op = std::make_unique<AudioVAEDepthwiseConvOpData>();
-    op->stride = stride;
-    op->dilation = dilation;
-    op->padding = padding;
-
-    AudioVAEDepthwiseConvOpData* op_ptr = op.get();
-    depthwise_ops_.push_back(std::move(op));
-    return ggml_map_custom3(ctx, x, weight, bias, depthwise_conv_custom, GGML_N_TASKS_MAX, op_ptr);
+    if (bias) result = ggml_add(ctx, result, reshape_bias_3d(ctx, bias));
+    return ggml_cont(ctx, result);
 }
 
 ggml_tensor* AudioVAE::causal_conv1d_dw_stateful(ggml_context* ctx,
@@ -696,55 +682,26 @@ ggml_tensor* AudioVAE::causal_conv1d_dw_stateful(ggml_context* ctx,
                                                  int padding,
                                                  AudioVAEStreamingDecodeState& state,
                                                  const std::string& state_name) const {
-    if (backend.type() == BackendType::Vulkan) {
-        // The GGML library in use does not define ggml_map_custom3 for Vulkan.
-        // This causes silent audio output (or occasionally popping noises).
-        // Replace unsupported ggml_map_custom3 call with standard depthwise convolution.
+    VOXCPM_ASSERT(backend.type() == BackendType::CUDA || backend.type() == BackendType::Vulkan);
 
-        const int64_t state_frames = padding * 2;
-        if (state_frames <= 0) return causal_conv1d_dw(ctx, backend, x, weight, bias, stride, dilation, padding);
-
-        ggml_tensor* x_full = ggml_concat(
-            ctx,
-            state.take_slot(state_frames, x->ne[1], state_name),
-            x,
-            0
-        );
-
-        const int64_t kernel = weight->ne[0];
-        ggml_tensor* result = conv1d_mul_mat_impl(ctx, weight, x_full, static_cast<int>(kernel), stride, dilation);
-
-        if (bias) result = ggml_add(ctx, result, reshape_bias_3d(ctx, bias));
-
-        const size_t state_offset = static_cast<size_t>(x_full->ne[0] - state_frames) * x_full->nb[0];
-        ggml_tensor* next_state = ggml_view_3d(
-            ctx, x_full, state_frames,
-            x_full->ne[1], x_full->ne[2],
-            x_full->nb[1], x_full->nb[2],
-            state_offset
-        );
-        next_state = ggml_cont(ctx, next_state);
-        state.queue_update(next_state);
-
-        return ggml_cont(ctx, result);
-    }
-
+    //VOXCPM_ASSERT(padding * 2 < INT_MAX);
     const int state_frames = padding * 2;
-    if (state_frames <= 0) {
-        return causal_conv1d_dw(ctx, backend, x, weight, bias, stride, dilation, padding);
-    }
+    if (state_frames <= 0) return causal_conv1d_dw(ctx, backend, x, weight, bias, stride, dilation, padding);
 
-    VOXCPM_ASSERT(backend.type() == BackendType::CUDA);
-    ggml_tensor* prev = state.take_slot(state_frames, x->ne[1], state_name);
-    ggml_tensor* x_full = ggml_concat(ctx, prev, x, 0);
+    // These *should* be inlined by the compiler. If they are not, they can be eliminated.
+    ggml_tensor* const prev = state.take_slot(state_frames, x->ne[1], state_name);
+    ggml_tensor* const x_full = ggml_concat(ctx, prev, x, 0);
+
     ggml_tensor* result = ggml_conv_1d_dw(ctx, weight, x_full, stride, 0, dilation);
-    if (bias) {
-        result = ggml_add(ctx, result, reshape_bias_3d(ctx, bias));
-    }
+    if (bias) result = ggml_add(ctx, result, reshape_bias_3d(ctx, bias));
 
     const size_t state_offset = static_cast<size_t>(x_full->ne[0] - state_frames) * x_full->nb[0];
-    ggml_tensor* next_state =
-        ggml_view_3d(ctx, x_full, state_frames, x_full->ne[1], x_full->ne[2], x_full->nb[1], x_full->nb[2], state_offset);
+    ggml_tensor* next_state = ggml_view_3d(
+        ctx, x_full, state_frames,
+        x_full->ne[1], x_full->ne[2],
+        x_full->nb[1], x_full->nb[2],
+        state_offset
+    );
     next_state = ggml_cont(ctx, next_state);
     state.queue_update(next_state);
     return ggml_cont(ctx, result);


### PR DESCRIPTION
This is mostly cosmetic, to reduce code duplication. The main functional differences are:
- `ggml_map_custom3` is now only attempted for the CPU backend, which excludes `BackendType::Metal` and `BackendType::Auto`. This seems like the safe approach, since any additional backends added to the enum would not be supported either (unless the library changes).
- Vulkan use of `conv1d_mul_mat_impl` is replaced with `causal_conv1d_dw` (as per https://github.com/bluryar/VoxCPM.cpp/pull/16/changes/61a58ebce8ba230f1b0a49b6b2d0bd7645032163).

The commented assert is there because INT_MAX isn't available and simply having that comment there seems safe enough. It can be uncommented if the limits library is ever included.

Since I can only test the Vulkan backend right now, the other backends should be tested before merging. I will update this once I have tested CPU and Auto. I can not test CUDA or Metal.